### PR TITLE
Fix pagination param validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker compose up --build
 docker exec api pytest
 ```
 
-### Coverage (%96):
+### Coverage (%95):
 
 ```
 docker exec api coverage run -m pytest
@@ -82,7 +82,7 @@ Redirect to URL
 
 #### Request:
 ```http request
-GET /urls/{short_url_path}?redirect=False
+GET /urls/{short_url_path}?redirect=false
 
 Query:
 redirect: bool = Redirect or get json (defaul=True)

--- a/source/app/url/schemas.py
+++ b/source/app/url/schemas.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+from typing import Any
 
-from pydantic import UUID4, BaseModel, Field, HttpUrl, model_validator
+from fastapi import HTTPException, status
+from pydantic import UUID4, BaseModel, Field, HttpUrl, ValidationError, model_validator
 
 from source.app.url.enums import Order, Sort
 from source.core.schemas import PageSchema, ResponseSchema
@@ -38,6 +40,15 @@ class UrlPage(PageSchema):
 
 class UrlPagination(BaseModel):
     page: int = Field(default=1, ge=1)
-    size: int = Field(default=50, ge=0)
+    size: int = Field(default=50, ge=1)
     sort: Sort = Sort.ID
     order: Order = Order.ASC
+
+    def __init__(self, **data: Any) -> None:
+        try:
+            super(UrlPagination, self).__init__(**data)
+        except ValidationError as error:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=error.errors(),
+            )

--- a/source/app/url/services.py
+++ b/source/app/url/services.py
@@ -35,7 +35,7 @@ async def list_url(
         page=page,
         size=size,
         total=total,
-        pages=((total + size - 1) // size if size else 1),
+        pages=((total + size - 1) // size),
     )
 
 

--- a/source/core/database.py
+++ b/source/core/database.py
@@ -19,7 +19,7 @@ async def get_db() -> AsyncGenerator[AsyncSession, Any]:
         await db.close()
 
 
-async def database_health(db) -> bool:
+async def database_health(db: AsyncSession) -> bool:
     try:
         await db.execute(select(1))
         return True

--- a/test/url/test_views.py
+++ b/test/url/test_views.py
@@ -52,6 +52,7 @@ async def test_url_redirect(client: AsyncClient, db: AsyncSession):
     response = await client.get(url=f"/urls/{url.shortened_url}")
 
     assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    assert response.headers["location"] == param
 
 
 @pytest.mark.asyncio
@@ -70,6 +71,13 @@ async def test_url_list(client: AsyncClient, db: AsyncSession):
     assert data["size"] == 5
     assert data["total"] is not None
     assert data["pages"] is not None
+
+    response = await client.get(url="/urls/", params={"page": -5, "size": -5})
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    data = response.json()
+    assert data["detail"][0]["loc"][0] == "page"
+    assert data["detail"][1]["loc"][0] == "size"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
There is an issue in the Pydantic model. The "Field(default=50, ge=1)" part raises a validation error, but FastAPI returns a 500 Internal Server Error instead of the expected 422 Unprocessable Entity status code.

Related to the use of Pydantic model with Fastapi Depends().

https://github.com/tiangolo/fastapi/discussions/8958

This PR fix this issue.