### PR TITLE
Add sort order so that id is always the first column

### DIFF
--- a/source/core/models.py
+++ b/source/core/models.py
@@ -12,9 +12,6 @@ class Model(Base):
     __abstract__ = True
 
     id: Mapped[int] = mapped_column(
-        primary_key=True,
-        autoincrement=True,
-        unique=True,
-        index=True,
+        primary_key=True, autoincrement=True, unique=True, index=True, sort_order=-1
     )
     create_date: Mapped[datetime] = mapped_column(default=func.now())


### PR DESCRIPTION
sort_order –

An integer that indicates how this mapped column should be sorted compared to the others when the ORM is creating a [Table](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table). Among mapped columns that have the same value the default ordering is used, placing first the mapped columns defined in the main class, then the ones in the super classes. Defaults to 0. The sort is ascending.